### PR TITLE
Fix for 'method not implemented' exceptions in Appium

### DIFF
--- a/src/main/java/com/codeborne/selenide/Selenide.java
+++ b/src/main/java/com/codeborne/selenide/Selenide.java
@@ -635,6 +635,9 @@ public class Selenide {
     if (!hasWebDriverStarted()) {
       return emptyList();
     }
+    if (WebDriverRunner.getWebDriver() instanceof AndroidDriver) {
+      return emptyList();
+    }
     else if (!supportsJavascript()) {
       return emptyList();
     }


### PR DESCRIPTION
#486
Fix addresses following issue;
getJavascriptErrors causes exceptions when element is not found in native app on Android
https://github.com/codeborne/selenide/issues/486
Added additional check to getJavascriptErrors() method.

Tested on local environment - works just fine:)